### PR TITLE
chore: bump actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu-latest
             rust: nightly
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -47,7 +47,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -68,7 +68,7 @@ jobs:
     name: Code coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -94,7 +94,7 @@ jobs:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Verify version matches tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Get tag version
         id: get_tag
@@ -37,7 +37,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       version: ${{ steps.get_version.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -96,7 +96,7 @@ jobs:
             target: aarch64-apple-darwin
             asset_name: commitkit-macos-arm64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'thomasvincent/commitkit-rust' # Only publish from the original repo
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -18,7 +18,7 @@ jobs:
     name: Update version and create tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Summary

This PR updates the `actions/checkout` action from v5 to v6 in all GitHub Actions workflows.

## Changes

- Update `actions/checkout@v5` → `actions/checkout@v6`

## Benefits

- Performance improvements
- Better support for newer GitHub features
- Keeps dependencies up to date
- Security improvements from the latest version

## Testing

The workflows will be automatically tested when this PR is opened. All existing functionality should continue to work as expected since v6 is backward compatible with v5.

## References

- [actions/checkout releases](https://github.com/actions/checkout/releases)
