### PR TITLE
security: Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign PR
-        uses: kentaro-m/auto-assign-action@v2.0.1
+        uses: kentaro-m/auto-assign-action@a6d59add3a817df08cafa9b166367768d2c337f8 # v2.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: thomasvincent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
           - os: ubuntu-latest
             rust: nightly
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # master
         with:
           toolchain: ${{ matrix.rust }}
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
 
       - name: Run tests
         run: cargo test --verbose
@@ -68,16 +68,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Prevent hung jobs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # master
         with:
           toolchain: stable
           components: rustfmt, clippy
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -97,15 +97,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Prevent hung jobs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # master
         with:
           toolchain: stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
 
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
@@ -114,7 +114,7 @@ jobs:
         run: cargo tarpaulin --out Xml
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,7 @@ jobs:
           echo "pr_title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
 
       - name: Wait for status checks
-        uses: fountainhead/action-wait-for-check@v1.2.0
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
         id: wait-for-checks
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,7 +31,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -43,7 +43,7 @@ jobs:
     name: Update version and create tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to SHA hashes across all workflows to prevent supply chain attacks
- Security audit already present in ci.yml (lines 129-152)

## Changes
Updated the following workflows:
- `ci.yml`: 4 action references pinned
- `auto-assign.yml`: 1 action reference pinned
- `dependabot-auto-merge.yml`: 1 action reference pinned
- `labeler.yml`: 1 action reference pinned
- `semver.yml`: 1 action reference pinned

## Actions Pinned
- `actions/checkout@v4` → `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`
- `dtolnay/rust-toolchain@master` → `dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7`
- `Swatinem/rust-cache@v2` → `Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db`
- `codecov/codecov-action@v5` → `codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de`
- `kentaro-m/auto-assign-action@v2.0.1` → `kentaro-m/auto-assign-action@a6d59add3a817df08cafa9b166367768d2c337f8`
- `fountainhead/action-wait-for-check@v1.2.0` → `fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be`
- `actions/labeler@v6` → `actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b`

## Security Benefits
Pinning actions to SHA hashes ensures that the workflow runs the exact version of the action that was reviewed, preventing malicious updates from being automatically pulled in.
