### PR TITLE
chore: harmonize Rust codebase formatting and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ CommitKit is a command-line tool that helps developers create well-structured an
   - Commit statistics and analysis
   - Interactive prompts for template values
 
+## Prerequisites
+
+- **Rust**: Version 1.85.0 or higher (MSRV)
+- **Cargo**: Included with Rust installation
+
 ## Installation
 
 ### From crates.io
@@ -135,6 +140,48 @@ commitkit --stats --days 30
 
 # Validate a commit message
 commitkit --validate .git/COMMIT_EDITMSG
+```
+
+## Development
+
+### Build
+
+```bash
+# Debug build
+cargo build
+
+# Release build
+cargo build --release
+```
+
+### Test
+
+```bash
+# Run all tests
+cargo test
+
+# Run tests with output
+cargo test -- --nocapture
+```
+
+### Lint
+
+```bash
+# Check for linting issues
+cargo clippy --all-targets --all-features
+
+# Apply automatic fixes
+cargo clippy --fix --allow-dirty
+```
+
+### Format
+
+```bash
+# Check formatting
+cargo fmt -- --check
+
+# Apply formatting
+cargo fmt
 ```
 
 ## Configuration

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+edition = "2021"
+
 # Maximum width of each line
 max_width = 100
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ pub fn setup_test_repo() -> TempDir {
 
     // Initialize git repo
     let status = std::process::Command::new("git")
-        .args(&["init"])
+        .args(["init"])
         .current_dir(temp_dir.path())
         .status()
         .expect("Failed to run git init");
@@ -30,13 +30,13 @@ pub fn setup_test_repo() -> TempDir {
 
     // Configure git for tests
     std::process::Command::new("git")
-        .args(&["config", "user.name", "Test User"])
+        .args(["config", "user.name", "Test User"])
         .current_dir(temp_dir.path())
         .status()
         .expect("Failed to configure git user name");
 
     std::process::Command::new("git")
-        .args(&["config", "user.email", "test@example.com"])
+        .args(["config", "user.email", "test@example.com"])
         .current_dir(temp_dir.path())
         .status()
         .expect("Failed to configure git user email");


### PR DESCRIPTION
## Summary
- Normalize code formatting with `cargo fmt`
- Apply automatic lint fixes with `cargo clippy --fix`
- Update rustfmt.toml with edition specification
- Update README.md with standardized development sections (Prerequisites, Installation, Development)

## Changes
- **Formatting**: Applied `cargo fmt --all` to normalize code style
- **Linting**: Applied `cargo clippy --fix` to address automatic fixes (removed duplicated cfg(test) attribute)
- **Configuration**: Updated `rustfmt.toml` to include `edition = "2021"`
- **Documentation**: Added Prerequisites section and comprehensive Development section (Build, Test, Lint, Format)

## Test Plan
- All formatting applied via `cargo fmt --all`
- Lint fixes applied via `cargo clippy --fix --allow-dirty`
- No functional changes - formatting and documentation only